### PR TITLE
change file size limit to 5mb

### DIFF
--- a/client/components/forms/run-form.jsx
+++ b/client/components/forms/run-form.jsx
@@ -87,7 +87,7 @@ export default function RunForm(props) {
   const handleGpxData = event => {
     setFetchingData(true);
     const file = event.target.files[0];
-    if (file.size > 10485760) {
+    if (file.size > 5242880) {
       fileInputRef.current.value = '';
       alert('File is too large. Maximum file size is 10MB.');
       return;

--- a/server/index.js
+++ b/server/index.js
@@ -23,7 +23,7 @@ app.use(timeout('15s'));
 
 app.use(staticMiddleware);
 
-app.use(express.json({ limit: '10mb' }));
+app.use(express.json({ limit: '5mb' }));
 
 // Auth Routes //
 


### PR DESCRIPTION
Biggest run I have recorded is a marathon that comes in around 4 mb. I'll give a little wiggle room on top of that but cap data off at 5mb.